### PR TITLE
Could not click in any select box on the ipad air

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -524,7 +524,7 @@
 							};
 
 							if (typeof $window.Hammer !== 'undefined') {
-								var hammerTime = scope.hammerTime = $window.Hammer($dialog[0]);
+								var hammerTime = scope.hammerTime = $window.Hammer($dialog[0], {touchAction: 'auto' });
 								hammerTime.on('tap', closeByDocumentHandler);
 							} else {
 								$dialog.bind('click', closeByDocumentHandler);


### PR DESCRIPTION
I use hammerjs and ngDialog quite heavy in my app. 
Have had some problems on the iPad with select boxes not being selctable in the dialoge in safari on I-devices. 

After I added the {touchAction: auto } to the hammer constructor it all semed to work. And haven't found anything broken yet.

According to this page does Safari uses the fallback option polyfill:
https://cdn.rawgit.com/hammerjs/hammer.js/master/tests/manual/touchaction.html
